### PR TITLE
ACS-8676 Deal with upcoming GitHub Actions deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     name: "Build"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.34.2
+      - uses: actions/checkout@v4
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
       - name: "Build"
         run: mvn -B -V -U clean org.jacoco:jacoco-maven-plugin:prepare-agent install
 
@@ -34,11 +34,11 @@ jobs:
       github.event_name != 'pull_request' &&
       !contains(github.event.head_commit.message, '[no-release]')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.34.2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v1.34.2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v7.0.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v7.0.0
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           email: ${{ secrets.BOT_GITHUB_EMAIL }}


### PR DESCRIPTION
Migrate from `Node16` to `Node20`.
Additionally: upgrading the version to the latest for other actions from the `alfresco-build-tools`.